### PR TITLE
Zoom control for tracker chart

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.19
+current_version = 0.9.20
 commit = False
 tag = False
 

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -3,7 +3,6 @@
   <component name="ChangeListManager">
     <list default="true" id="4062e2d3-3d94-4dd0-96cb-ffd3a3879a3b" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/interceptor/gui/tracker.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/interceptor/gui/tracker.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -32,7 +31,6 @@
   <component name="ProjectViewState">
     <option name="autoscrollToSource" value="true" />
     <option name="hideEmptyMiddlePackages" value="true" />
-    <option name="showExcludedFiles" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
   <component name="PropertiesComponent">
@@ -70,6 +68,10 @@
     <servers />
   </component>
   <component name="WindowStateProjectService">
+    <state x="968" y="475" key="#com.intellij.openapi.updateSettings.impl.PluginUpdateInfoDialog" timestamp="1586472978782">
+      <screen x="0" y="23" width="2560" height="1417" />
+    </state>
+    <state x="968" y="475" key="#com.intellij.openapi.updateSettings.impl.PluginUpdateInfoDialog/0.23.2560.1417/-1680.23.1680.1027@0.23.2560.1417" timestamp="1586472978782" />
     <state x="928" y="332" key="CommitChangelistDialog2" timestamp="1586215002466">
       <screen x="0" y="23" width="2560" height="1417" />
     </state>

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     author="Artem Y. Lyubimov",
     author_email="lyubimov@stanford.edu",
-    version="0.9.19",
+    version="0.9.20",
     url="https://github.com/alyubimov/interceptor",
     license="BSD",
     install_requires=[],

--- a/src/interceptor/__init__.py
+++ b/src/interceptor/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.19'
+__version__ = '0.9.20'
 
 try:
   import importlib.resources as pkg_resources

--- a/src/interceptor/gui/tracker.py
+++ b/src/interceptor/gui/tracker.py
@@ -274,7 +274,7 @@ class TrackChart(wx.Panel):
         pageSize=self.chart_range
       )
       self.plot_sb.Show()
-      self.zoom_ctrl.update(
+      self.zoom_ctrl.set_control(
         max_lock=False,
         plot_zoom=True,
         chart_range=self.chart_range
@@ -333,7 +333,7 @@ class TrackChart(wx.Panel):
       self.bracket_set = False
       self.plot_zoom = False
       self.plot_sb.Hide()
-      self.zoom_ctrl.update(
+      self.zoom_ctrl.set_control(
         max_lock=False,
         plot_zoom=False,
       )


### PR DESCRIPTION
(Note: this branch should've been opened the moment I decided to create a set of zoom controls for the tracker chart. Oops.)

The zoom control is composed of a "zoom" toggle button, which determines whether a full chart is displayed (when it's off), or a portion of the chart (when it's on). The portion of the chart is determined by the chart range spin control. Next to it are buttons that advance the displayed chart range forward or backward by 1/10 of the chart range. Finally, the max lock toggle button, when on, will cause the final X images to be displayed, where X = chart range.