### PR TITLE
Detector registry and dynamic format class selection

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.30.4
+current_version = 0.30.5
 commit = False
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.30.0
+current_version = 0.30.1
 commit = False
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.30.2
+current_version = 0.30.3
 commit = False
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.30.1
+current_version = 0.30.2
 commit = False
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.29.9
+current_version = 0.30.0
 commit = False
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.30.3
+current_version = 0.30.4
 commit = False
 tag = False
 

--- a/doc/NOTES.txt
+++ b/doc/NOTES.txt
@@ -1,8 +1,7 @@
-10.10.2022 - trial of internal ExperimentList generation
+10.24.2022 - Detector "registry"
 
-- for file-based standalone interceptor, use the usual ExperimentListFactory.from_filenames()
-- for ZMQ Interceptor:
-    - import Eiger or Pilatus ZMQ-capable format class
-    - create imageset directly
-    - use imageset with ExperimentListFactory.from_stills_and_crystal()
-- a dummy filename is no longer passed to ZMQ interceptor
+- A more customizable way to match detector with datastream
+    - a customizable JSON file included with settings (and with Interceptor distro)
+    - a setting pointing to this file
+    - 'detector' setting used to pull the matching detector info from dictionary
+    - the right format class is imported and instantiated from interceptor.format

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     author="Artem Y. Lyubimov",
     author_email="lyubimov@stanford.edu",
-    version="0.30.1",
+    version="0.30.2",
     url="https://github.com/ssrl-px/interceptor",
     license="BSD",
     install_requires=[],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     author="Artem Y. Lyubimov",
     author_email="lyubimov@stanford.edu",
-    version="0.30.2",
+    version="0.30.3",
     url="https://github.com/ssrl-px/interceptor",
     license="BSD",
     install_requires=[],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     author="Artem Y. Lyubimov",
     author_email="lyubimov@stanford.edu",
-    version="0.29.9",
+    version="0.30.0",
     url="https://github.com/ssrl-px/interceptor",
     license="BSD",
     install_requires=[],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     author="Artem Y. Lyubimov",
     author_email="lyubimov@stanford.edu",
-    version="0.30.3",
+    version="0.30.4",
     url="https://github.com/ssrl-px/interceptor",
     license="BSD",
     install_requires=[],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     author="Artem Y. Lyubimov",
     author_email="lyubimov@stanford.edu",
-    version="0.30.4",
+    version="0.30.5",
     url="https://github.com/ssrl-px/interceptor",
     license="BSD",
     install_requires=[],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     author="Artem Y. Lyubimov",
     author_email="lyubimov@stanford.edu",
-    version="0.30.0",
+    version="0.30.1",
     url="https://github.com/ssrl-px/interceptor",
     license="BSD",
     install_requires=[],

--- a/src/interceptor/__init__.py
+++ b/src/interceptor/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.30.3"
+__version__ = "0.30.4"
 
 import os
 import platform

--- a/src/interceptor/__init__.py
+++ b/src/interceptor/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.30.0"
+__version__ = "0.30.1"
 
 import os
 import platform

--- a/src/interceptor/__init__.py
+++ b/src/interceptor/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.29.9"
+__version__ = "0.30.0"
 
 import os
 import platform

--- a/src/interceptor/__init__.py
+++ b/src/interceptor/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.30.4"
+__version__ = "0.30.5"
 
 import os
 import platform

--- a/src/interceptor/__init__.py
+++ b/src/interceptor/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.30.1"
+__version__ = "0.30.2"
 
 import os
 import platform

--- a/src/interceptor/__init__.py
+++ b/src/interceptor/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.30.2"
+__version__ = "0.30.3"
 
 import os
 import platform

--- a/src/interceptor/connector/connector.py
+++ b/src/interceptor/connector/connector.py
@@ -184,6 +184,7 @@ class Reader(ZMQProcessBase):
             name=name, comm=comm, args=args, localhost=localhost
         )
         self.name = "ZMQ_{:03d}".format(self.rank)
+        self.detector = self.find_detector()
         self.generate_processor()
 
         # Initialize ZMQ sockets
@@ -333,8 +334,7 @@ class Reader(ZMQProcessBase):
             self.generate_processor(run_mode=info['run_mode'])
 
         # process image
-        detector = self.find_detector()
-        info = self.processor.run(data=frame, info=info, detector=detector)
+        info = self.processor.run(data=frame, info=info, detector=self.detector)
         info["proc_time"] = time.time() - s_proc
         return info
 
@@ -444,7 +444,7 @@ class Reader(ZMQProcessBase):
                         info.update(time_info)
                     # end-of-series signal (sleep for four seconds... maybe obsolete)
                     elif info["state"] == "series-end":
-                        time.sleep(4)
+                        time.sleep(self.detector['timeout'])
                         continue
 
                     # send info to collector or direct to UI

--- a/src/interceptor/connector/processor.py
+++ b/src/interceptor/connector/processor.py
@@ -423,6 +423,7 @@ class InterceptorBaseProcessor(object):
             load_models = True
             fc_string = "interceptor.format.{}".format(detector['format_class'])
             fc_module = importlib.import_module(fc_string)
+            fc_module.data = data
             fc_class = getattr(fc_module, detector['format_class'])
             format_class = fc_class(image_file=filename)
 

--- a/src/interceptor/connector/processor.py
+++ b/src/interceptor/connector/processor.py
@@ -419,7 +419,6 @@ class InterceptorBaseProcessor(object):
 
         elif data is not None:
             # ExperimentList creation with ZeroMQ format classes
-            #TODO: I *will* need to somehow mimic a registry...
             assert detector is not None
             load_models = True
             fc_string = "interceptor.format.{}".format(detector['format_class'])

--- a/src/interceptor/connector/processor.py
+++ b/src/interceptor/connector/processor.py
@@ -9,6 +9,7 @@ Description : Streaming stills processor for live data analysis
 import time  # noqa: F401; keep around for testing
 
 import numpy as np
+import importlib
 
 from cctbx import sgtbx, crystal
 from iotbx import phil as ip
@@ -405,7 +406,6 @@ class InterceptorBaseProcessor(object):
         diff_phil.show()
         print("\n")
 
-    @staticmethod
     def make_experiments(filename=None, data=None, detector=None):
         # make experiments
         e_start = time.time()
@@ -421,19 +421,23 @@ class InterceptorBaseProcessor(object):
             #TODO: I *will* need to somehow mimic a registry...
             assert detector is not None
             load_models = True
+            fc_string = "interceptor.format.{}".format(detector['format_class'])
+            fc_module = importlib.import_module(fc_string)
+            fc_class = getattr(fc_module, detector['format_class'])
+            format_class = fc_class()
 
-            # Generate format class explicitly
-            if 'eiger' in detector.lower():
-                from interceptor.format import FormatEigerStream
-                FormatEigerStream.injected_data = data
-                format_class = FormatEigerStream.FormatEigerStream()
-            elif 'pilatus' in detector.lower():
-                from interceptor.format import FormatPilatusStream
-                FormatPilatusStream.injected_data = data
-                format_class = FormatPilatusStream.FormatPilatusStream(image_file=str(filename))
-            else:
-                sorry_msg = "Detector {} NOT FOUND!"
-                raise Sorry(sorry_msg)
+            # # Generate format class explicitly
+            # if 'eiger' in detector.lower():
+            #     from interceptor.format import FormatEigerStream
+            #     FormatEigerStream.injected_data = data
+            #     format_class = FormatEigerStream.FormatEigerStream()
+            # elif 'pilatus' in detector.lower():
+            #     from interceptor.format import FormatPilatusStream
+            #     FormatPilatusStream.injected_data = data
+            #     format_class = FormatPilatusStream.FormatPilatusStream()
+            # else:
+            #     sorry_msg = "Detector {} NOT FOUND!"
+            #     raise Sorry(sorry_msg)
 
             # Inject data and create imageset
             reader = MemReaderNamedPath("virtual_datastream_path", [format_class])
@@ -565,15 +569,18 @@ class FileProcessor(InterceptorBaseProcessor):
         info['proc_time'] = time.time() - start
         return info
 
+
 class ZMQProcessor(InterceptorBaseProcessor):
     def __init__(
             self,
             run_mode='DEFAULT',
             configfile=None,
+            detectorfile=None,
             test=False,
     ):
         InterceptorBaseProcessor.__init__(self, run_mode=run_mode,
-                                          configfile=configfile, test=test)
+                                          configfile=configfile,
+                                          test=test)
 
     def process(self, data, detector, info):
         info["phil"] = self.dials_phil.as_str()
@@ -617,8 +624,7 @@ class ZMQProcessor(InterceptorBaseProcessor):
         # Doing it here because scoring can reject spots within ice rings, which can
         # drop the number below the minimal limit
         if info['n_spots'] < self.cfg.getint('min_Bragg_peaks'):
-            info[
-                "spf_error"] = "Too few ({}) spots found!".format(
+            info["spf_error"] = "Too few ({}) spots found!".format(
                 observed.size())
 
         # if last stage was selected to be "spotfinding", stop here; otherwise

--- a/src/interceptor/connector/processor.py
+++ b/src/interceptor/connector/processor.py
@@ -425,20 +425,7 @@ class InterceptorBaseProcessor(object):
             fc_string = "interceptor.format.{}".format(detector['format_class'])
             fc_module = importlib.import_module(fc_string)
             fc_class = getattr(fc_module, detector['format_class'])
-            format_class = fc_class()
-
-            # # Generate format class explicitly
-            # if 'eiger' in detector.lower():
-            #     from interceptor.format import FormatEigerStream
-            #     FormatEigerStream.injected_data = data
-            #     format_class = FormatEigerStream.FormatEigerStream()
-            # elif 'pilatus' in detector.lower():
-            #     from interceptor.format import FormatPilatusStream
-            #     FormatPilatusStream.injected_data = data
-            #     format_class = FormatPilatusStream.FormatPilatusStream()
-            # else:
-            #     sorry_msg = "Detector {} NOT FOUND!"
-            #     raise Sorry(sorry_msg)
+            format_class = fc_class(image_file=filename)
 
             # Inject data and create imageset
             reader = MemReaderNamedPath("virtual_datastream_path", [format_class])

--- a/src/interceptor/connector/processor.py
+++ b/src/interceptor/connector/processor.py
@@ -423,7 +423,7 @@ class InterceptorBaseProcessor(object):
             load_models = True
             fc_string = "interceptor.format.{}".format(detector['format_class'])
             fc_module = importlib.import_module(fc_string)
-            fc_module.data = data
+            fc_module.injected_data = data
             fc_class = getattr(fc_module, detector['format_class'])
             format_class = fc_class(image_file=filename)
 

--- a/src/interceptor/connector/processor.py
+++ b/src/interceptor/connector/processor.py
@@ -406,6 +406,7 @@ class InterceptorBaseProcessor(object):
         diff_phil.show()
         print("\n")
 
+    @staticmethod
     def make_experiments(filename=None, data=None, detector=None):
         # make experiments
         e_start = time.time()

--- a/src/interceptor/format/FormatEigerStream.py
+++ b/src/interceptor/format/FormatEigerStream.py
@@ -43,7 +43,7 @@ class FormatEigerStream(FormatMultiImage, Format):
 
     def __init__(self, image_file=None, **kwargs):
         if not injected_data:
-            raise IncorrectFormatError(self)
+            raise IncorrectFormatError(self, image_file)
 
         self.header = {
             "configuration": json.loads(injected_data.get("header2", "")),

--- a/src/interceptor/format/FormatEigerStream.py
+++ b/src/interceptor/format/FormatEigerStream.py
@@ -41,7 +41,7 @@ class FormatEigerStream(FormatMultiImage, Format):
             else:
                 return False
 
-    def __init__(self, **kwargs):
+    def __init__(self, image_file=None, **kwargs):
         if not injected_data:
             raise IncorrectFormatError(self)
 
@@ -56,7 +56,7 @@ class FormatEigerStream(FormatMultiImage, Format):
         self._scan_instance = None
 
         FormatMultiImage.__init__(self, **kwargs)
-        Format.__init__(self, image_file=None, **kwargs)
+        Format.__init__(self, image_file, **kwargs)
 
         self.setup()
 

--- a/src/interceptor/format/FormatPilatusStream.py
+++ b/src/interceptor/format/FormatPilatusStream.py
@@ -46,7 +46,7 @@ class FormatPilatusStream(FormatMultiImage, Format):
 
     def __init__(self, image_file, **kwargs):
         if not injected_data:
-            raise IncorrectFormatError(self)
+            raise IncorrectFormatError(self, image_file)
 
         self.header = {
             "configuration": json.loads(injected_data.get("header2", "")),

--- a/src/interceptor/resources/connector/startup.cfg
+++ b/src/interceptor/resources/connector/startup.cfg
@@ -15,6 +15,7 @@ send_to_ui = False
 timeout = None
 header_type = cbfToEiger-0.1
 processing_config_file = None
+detector_registry_file = None
 output_delimiter = None
 output_format = series, frame, result {}, mapping {}, filename
 output_prefix_key = reporting

--- a/src/interceptor/resources/format/detectors.json
+++ b/src/interceptor/resources/format/detectors.json
@@ -1,0 +1,8 @@
+{
+  "EIGER": {
+    "format_class": "FormatEigerStream"
+  },
+  "PILATUS": {
+    "format_class": "FormatPilatusStream"
+  }
+}

--- a/src/interceptor/resources/format/detectors.json
+++ b/src/interceptor/resources/format/detectors.json
@@ -1,8 +1,10 @@
 {
   "EIGER": {
-    "format_class": "FormatEigerStream"
+    "format_class": "FormatEigerStream",
+    "timeout": 4
   },
   "PILATUS": {
-    "format_class": "FormatPilatusStream"
+    "format_class": "FormatPilatusStream",
+    "timeout": 4
   }
 }


### PR DESCRIPTION
Created a rudimentary "registry" for detectors, specifying a format class for each kind, with room for other detector-specific options, e.g. end-of-series pause (required for Eiger, not so much for Pilatus). New format classes can be added to the Interceptor distribution, with corresponding explicit settings specifying which detector is present at which beamline. This does away entirely with the `understand` function in these custom format classes. As a result, these format classes do not require a file to be present in order to work.